### PR TITLE
Fix transparent navbar

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -22,10 +22,12 @@
 }
 
 html[data-theme='light'] {
+  --ifm-navbar-background-color: #FFFFFF;
 }
 
 html[data-theme='dark'] {
   --ifm-background-surface-color: #070C1A;
+  --ifm-navbar-background-color: #18191A;
   --ifm-color-primary: #657385;
   --ifm-heading-color: #FFFFFF;
   --ifm-font-color-base: #9EA5B8;


### PR DESCRIPTION
There's a transparent navbar presently, which causes menu text to overlap with body text.

I'm unsure if this is intended behaviour, however I thought it would be faster to make a PR than ask.

This change alters the navbar to have white and dark backgrounds for light and dark modes, respectively.

![Screen Shot 2021-04-13 at 10 23 23 AM](https://user-images.githubusercontent.com/66176/114487532-53a48e80-9c42-11eb-8b2d-4b550ea27c51.png)
